### PR TITLE
Update README to use the 1.+ version

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Here is how to include the spring cloud stream starter in your project using Gra
 
 ```groovy
 // Solace Spring Cloud Stream Binder
-compile("com.solace.spring.cloud:spring-cloud-starter-stream-solace:0.+")
+compile("com.solace.spring.cloud:spring-cloud-starter-stream-solace:1.+")
 ```
 
 #### Using it with Maven
@@ -69,7 +69,7 @@ compile("com.solace.spring.cloud:spring-cloud-starter-stream-solace:0.+")
 <dependency>
   <groupId>com.solace.spring.cloud</groupId>
   <artifactId>spring-cloud-starter-stream-solace</artifactId>
-  <version>0.+</version>
+  <version>1.+</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Update README instructions to include the 1.+ binder instead of 0.+.