### PR TITLE
SOL-18996 & SOL-18930: applicationMessageId & header validation Java identifier syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Here is how to include the spring cloud stream starter in your project using Gra
 
 ```groovy
 // Solace Spring Cloud Stream Binder
-compile("com.solace.spring.cloud:spring-cloud-starter-stream-solace:1.1.+")
+compile("com.solace.spring.cloud:spring-cloud-starter-stream-solace:2.0.+")
 ```
 
 #### Using it with Maven
@@ -69,7 +69,7 @@ compile("com.solace.spring.cloud:spring-cloud-starter-stream-solace:1.1.+")
 <dependency>
   <groupId>com.solace.spring.cloud</groupId>
   <artifactId>spring-cloud-starter-stream-solace</artifactId>
-  <version>1.1.+</version>
+  <version>2.0.+</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.solace.spring.cloud</groupId>
   <artifactId>spring-cloud-stream-binder-solace-parent</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Solace Spring Cloud Stream Starter and Binder</name>
   <description>Parent POM for the Solace Spring Cloud Stream Binder</description>

--- a/spring-cloud-starter-stream-solace/pom.xml
+++ b/spring-cloud-starter-stream-solace/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.solace.spring.cloud</groupId>
     <artifactId>spring-cloud-stream-binder-solace-parent</artifactId>
-	<version>1.2.0-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/spring-cloud-stream-binder-solace-core/pom.xml
+++ b/spring-cloud-stream-binder-solace-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.solace.spring.cloud</groupId>
     <artifactId>spring-cloud-stream-binder-solace-parent</artifactId>
-	<version>1.2.0-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/spring-cloud-stream-binder-solace-core/src/main/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapper.java
+++ b/spring-cloud-stream-binder-solace-core/src/main/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapper.java
@@ -43,7 +43,7 @@ public class XMLMessageMapper {
 	static final String JAVA_SERIALIZED_OBJECT_HEADER = "isJavaSerializedObject";
 	private static final String HEADER_JAVA_SERIALIZED_OBJECT_HEADER = "_" + JAVA_SERIALIZED_OBJECT_HEADER + "_";
 	static final String BINDER_VERSION_HEADER = "solaceSpringCloudStreamBinderVersion";
-	static final String BINDER_VERSION = "0.1.0"; //TODO Determine this dynamically
+	static final String BINDER_VERSION = "2.0.0"; //TODO Determine this dynamically
 
 	static {
 		BINDER_INTERNAL_HEADERS = new HashSet<>();

--- a/spring-cloud-stream-binder-solace-core/src/main/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapper.java
+++ b/spring-cloud-stream-binder-solace-core/src/main/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapper.java
@@ -41,7 +41,7 @@ public class XMLMessageMapper {
 	private static final JCSMPAcknowledgementCallbackFactory ackCallbackFactory = new JCSMPAcknowledgementCallbackFactory();
 	static final Set<String> BINDER_INTERNAL_HEADERS;
 	static final String JAVA_SERIALIZED_OBJECT_HEADER = "isJavaSerializedObject";
-	private static final String HEADER_JAVA_SERIALIZED_OBJECT_HEADER = "_" + JAVA_SERIALIZED_OBJECT_HEADER + "-";
+	private static final String HEADER_JAVA_SERIALIZED_OBJECT_HEADER = "_" + JAVA_SERIALIZED_OBJECT_HEADER + "_";
 	static final String BINDER_VERSION_HEADER = "solaceSpringCloudStreamBinderVersion";
 	static final String BINDER_VERSION = "0.1.0"; //TODO Determine this dynamically
 

--- a/spring-cloud-stream-binder-solace-core/src/main/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapper.java
+++ b/spring-cloud-stream-binder-solace-core/src/main/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapper.java
@@ -42,6 +42,7 @@ public class XMLMessageMapper {
 	static final Set<String> BINDER_INTERNAL_HEADERS;
 	static final String JAVA_SERIALIZED_OBJECT_HEADER = "isJavaSerializedObject";
 	private static final String HEADER_JAVA_SERIALIZED_OBJECT_HEADER = "_" + JAVA_SERIALIZED_OBJECT_HEADER + "_";
+	static final String HEADER_APPLICATION_MESSAGE_ID = "applicationMessageId";
 	static final String BINDER_VERSION_HEADER = "solaceSpringCloudStreamBinderVersion";
 	static final String BINDER_VERSION = "2.0.0"; //TODO Determine this dynamically
 
@@ -113,6 +114,11 @@ public class XMLMessageMapper {
 		MimeType contentType = StaticMessageHeaderAccessor.getContentType(message);
 		if (contentType != null) {
 			xmlMessage.setHTTPContentType(contentType.toString());
+		}
+
+		Object applicationMessageId = message.getHeaders().get(HEADER_APPLICATION_MESSAGE_ID);
+		if (applicationMessageId != null && applicationMessageId instanceof String) {
+			xmlMessage.setApplicationMessageId((String) applicationMessageId);
 		}
 
 		xmlMessage.setProperties(metadata);

--- a/spring-cloud-stream-binder-solace-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
+++ b/spring-cloud-stream-binder-solace-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 public class XMLMessageMapperTest {
 	@Spy
@@ -377,6 +378,13 @@ public class XMLMessageMapperTest {
 
 		Assert.assertThat(sdtMap.keySet(), CoreMatchers.hasItem(key));
 		Assert.assertThat(sdtMap.keySet(), CoreMatchers.hasItem(xmlMessageMapper.getIsHeaderSerializedMetadataKey(key)));
+		Assert.assertThat(String.format("A header key is an invalid Java identifier: %s", sdtMap.keySet()),
+				sdtMap.keySet()
+						.stream()
+						.map(h -> Character.isJavaIdentifierStart(h.charAt(0)) &&
+								h.chars().skip(1).allMatch(Character::isJavaIdentifierPart))
+						.collect(Collectors.toSet()),
+				CoreMatchers.everyItem(CoreMatchers.is(true)));
 		Assert.assertThat(sdtMap.values(), CoreMatchers.everyItem(CoreMatchers.not(CoreMatchers.instanceOf(ByteArray.class))));
 		Assert.assertEquals(value, deserializeHeader(sdtMap, key));
 		Assert.assertEquals(true, sdtMap.getBoolean(xmlMessageMapper.getIsHeaderSerializedMetadataKey(key)));

--- a/spring-cloud-stream-binder-solace-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
+++ b/spring-cloud-stream-binder-solace-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
@@ -145,6 +145,21 @@ public class XMLMessageMapperTest {
 		validateXMLMessage(xmlMessage, testSpringMessage);
 	}
 
+	@Test
+	public void testMapSpringMessageToXMLMessage_JCSMPPropertyForwarding() {
+		String applicationMessageId = "some-generated-application-msg-id";
+
+		Message<?> testSpringMessage = new DefaultMessageBuilderFactory()
+				.withPayload(new byte[0])
+				.setHeader(XMLMessageMapper.HEADER_APPLICATION_MESSAGE_ID, applicationMessageId)
+				.build();
+
+		XMLMessage xmlMessage = xmlMessageMapper.map(testSpringMessage);
+
+		// Doesn't include content-type testing since that's already tested everywhere else
+		Assert.assertEquals(applicationMessageId, xmlMessage.getApplicationMessageId());
+	}
+
 	@Test(expected = SolaceMessageConversionException.class)
 	public void testFailMapSpringMessageToXMLMessage_InvalidPayload() {
 		Message<?> testSpringMessage = new DefaultMessageBuilderFactory().withPayload(new Object()).build();

--- a/spring-cloud-stream-binder-solace/pom.xml
+++ b/spring-cloud-stream-binder-solace/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.solace.spring.cloud</groupId>
     <artifactId>spring-cloud-stream-binder-solace-parent</artifactId>
-	<version>1.2.0-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
* Restrict header keys to adhere to Java identifier syntax
* Special forwarding/mapping of the applicationMessageId header from Spring messages to JCMSP messages
* Set 2.0.0 version expectation (the changes on this branch are not backwards compatible)