### PR TITLE
Upgrade solace-java-spring-boot to 3.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
       <dependency>
         <groupId>com.solace.spring.boot</groupId>
         <artifactId>solace-java-spring-boot-starter</artifactId>
-        <version>3.2.0</version>
+        <version>3.2.1</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Fixes transient Jackson dependency issues when Jackson 3.x is present in Maven repositories.